### PR TITLE
Changing work computing function

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -725,6 +725,7 @@ public:
 
     // (memory only) Total amount of work (expected number of hashes) in the chain up to and including this block
     uint256 nChainWork;
+    uint256 nAlgoWork[NUM_ALGOS];
 
     // Number of transactions in this block.
     // Note: in a potential headers-first mode, this number cannot be relied upon
@@ -755,6 +756,8 @@ public:
         nDataPos = 0;
         nUndoPos = 0;
         nChainWork = 0;
+        for (int i = 0; i < NUM_ALGOS; i++)
+            nAlgoWork[i] = 0;
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
@@ -776,6 +779,8 @@ public:
         nDataPos = 0;
         nUndoPos = 0;
         nChainWork = 0;
+        for (int i = 0; i < NUM_ALGOS; i++)
+            nAlgoWork[i] = 0;
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;


### PR DESCRIPTION
Issue description at http://www.reddit.com/r/myriadcoin/comments/2oj7y5/lowhashrate_51_attack_on_myriad_without_timewarp/

I originally developed this approach for DigiByte, but never bothered to push.  The idea is to compare work done by each of the 5 algorithms individually, so an attacker has to 51% at least 3 algorithms in order to 51% the network (which is a less than ideal condition, but still seems to be an improvement over the current state).
